### PR TITLE
Fixes regarding colormap and colorbar for phi

### DIFF
--- a/003_modeling/SWS_modeling_calc_misfit.m
+++ b/003_modeling/SWS_modeling_calc_misfit.m
@@ -306,7 +306,7 @@ cbar_phi_ind = input(['Add colorbar for phi (default no)?: \n' ...
                       '    [0] no  [1] yes    | ']);
 
 % set phi colorbar string for file name
-if cmap_phi_ind~=0 && cbar_phi_ind==1
+if cmap_phi_ind~=0 & cbar_phi_ind==1
     cbar_phi_str = '_cb_';
 else
     cbar_phi_str = '_';

--- a/003_modeling/SWS_modeling_calc_misfit.m
+++ b/003_modeling/SWS_modeling_calc_misfit.m
@@ -316,11 +316,10 @@ end
 % default values
 if isempty(cmap_phi_ind)
     cmap_phi_ind = 0; % no
-    cmap_phi_str = '';
-    cbar_phi_ind = 0; % no
-    cbar_phi_str = '_';
     cmap_phi = "";
     cmap_phi_str = 'phino';
+    cbar_phi_ind = 0; % no
+    cbar_phi_str = '_';
 end
 
 

--- a/003_modeling/SWS_modeling_calc_misfit.m
+++ b/003_modeling/SWS_modeling_calc_misfit.m
@@ -319,6 +319,8 @@ if isempty(cmap_phi_ind)
     cmap_phi_str = '';
     cbar_phi_ind = 0; % no
     cbar_phi_str = '_';
+    cmap_phi = "";
+    cmap_phi_str = 'phino';
 end
 
 


### PR DESCRIPTION
This PR contains fixes regarding colormap and colorbar for phi:
- change operator `&&` to `&`
- add default for `cmap_phi`
- adjust default for `cmap_phi_str`